### PR TITLE
Issues Fixed 8.0

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -13,11 +13,15 @@ api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('token');
     if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+      config.headers['Authorization'] = `Bearer ${token}`;
+      console.log('Adding token to request:', token.substring(0, 10) + '...');
+    } else {
+      console.log('No token found in localStorage');
     }
     return config;
   },
   (error) => {
+    console.error('Request interceptor error:', error);
     return Promise.reject(error);
   }
 );
@@ -27,7 +31,7 @@ api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      // Clear auth data and redirect to login
+      console.log('Received 401, clearing auth data');
       localStorage.removeItem('token');
       localStorage.removeItem('user');
       window.location.href = '/login';

--- a/frontend/src/pages/GoogleCallback.jsx
+++ b/frontend/src/pages/GoogleCallback.jsx
@@ -11,7 +11,11 @@ const GoogleCallback = () => {
     const token = searchParams.get('token');
     const userData = searchParams.get('user');
 
-    console.log('Received callback data:', { token: !!token, userData: !!userData });
+    console.log('Received callback data:', { 
+      hasToken: !!token, 
+      hasUserData: !!userData,
+      tokenPreview: token ? token.substring(0, 10) + '...' : null
+    });
 
     if (token && userData) {
       try {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced logging for authentication token handling

- Improved debug output in Google OAuth callback

- Added error logging for request interceptor failures

- Clarified 401 response handling with explicit logs


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthContext.jsx</strong><dd><code>Enhanced authentication and error logging in AuthContext</code>&nbsp; </dd></summary>
<hr>

frontend/src/context/AuthContext.jsx

<li>Added detailed logging when adding token to request headers<br> <li> Logged absence of token in localStorage<br> <li> Added error logging for request interceptor failures<br> <li> Added explicit log when handling 401 unauthorized responses


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S85_Shivansh-Garg_Capstone_Notora/pull/38/files#diff-8c0c42e245a6f96ffa9fdc38c19cfe5a8110e23ee68f5fc139b55bf4b644bbde">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GoogleCallback.jsx</strong><dd><code>Enhanced debug logging for Google OAuth callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/pages/GoogleCallback.jsx

<li>Improved console logging for received OAuth callback data<br> <li> Added token preview to debug output for easier tracing


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S85_Shivansh-Garg_Capstone_Notora/pull/38/files#diff-1d6b5259afcc036ceb897584a13ccb9596c8d09222153a07dc9c00915e438dc3">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>